### PR TITLE
fix: broken link

### DIFF
--- a/mgmt_asset_risk/demo/demo.xml
+++ b/mgmt_asset_risk/demo/demo.xml
@@ -3,7 +3,7 @@
     <record id="mgmt_risk.demo_risk_server_outage" model="mgmt.risk">
         <field
             name="asset_ids"
-            eval="[(6, 0, [ref('mgmt_asset.demo_asset_server')])]"
+            eval="[(6, 0, [ref('mgmt_asset_maintenance.demo_asset_server')])]"
         />
     </record>
 


### PR DESCRIPTION
fix: broken link

With the introduction of mgmt_asset_maintenance and moving the demo data from mgmt_asset to this module, the link to demo data in mgmt_asset_risk was not updated.